### PR TITLE
update RSB/C/T from 0.13 to 0.15

### DIFF
--- a/rsb-gstreamer.rb
+++ b/rsb-gstreamer.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class RsbGstreamer < Formula
   homepage 'https://toolkit.cit-ec.uni-bielefeld.de/components/tools/rsb-gstreamer-integration'
-  url 'https://code.cor-lab.de/git/rsb-gstreamer.git', :using => :git, :branch => '0.13'
-  version '0.13'
+  url 'https://code.cor-lab.de/git/rsb-gstreamer.git', :using => :git, :branch => '0.15'
+  version '0.15'
   head 'https://code.cor-lab.de/git/rsb-gstreamer.git', :using => :git
 
   option :universal

--- a/rsb-opencv.rb
+++ b/rsb-opencv.rb
@@ -3,7 +3,7 @@ require 'formula'
 class RsbOpencv < Formula
   #homepage 'https://toolkit.cit-ec.uni-bielefeld.de/components/tools/rsb-gstreamer-integration'
   url 'https://code.cor-lab.de/svn/rsbvideoreceiver/branches/refactoring', :using => :svn
-  version '0.13'
+  version '0.15'
   head 'https://code.cor-lab.org/svn/rsbvideoreceiver/trunk', :using => :svn
 
   option :universal

--- a/rsb-protocol.rb
+++ b/rsb-protocol.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class RsbProtocol < Formula
   homepage 'https://code.cor-lab.org/projects/rsb'
-  url 'https://code.cor-lab.org/git/rsb.git.protocol', :using => :git, :branch => '0.13'
-  version '0.13'
+  url 'https://code.cor-lab.org/git/rsb.git.protocol', :using => :git, :branch => '0.15'
+  version '0.15'
   head 'https://code.cor-lab.org/git/rsb.git.protocol', :using => :git
 
   option :universal

--- a/rsb-spread-cpp.rb
+++ b/rsb-spread-cpp.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class RsbSpreadCpp < Formula
   homepage 'https://toolkit.cit-ec.uni-bielefeld.de/components/generic/robotics-service-bus'
-  url 'https://code.cor-lab.org/git/rsb.git.spread-cpp', :using => :git, :branch => '0.13'
-  version '0.13'
+  url 'https://code.cor-lab.org/git/rsb.git.spread-cpp', :using => :git, :branch => '0.15'
+  version '0.15'
   head 'https://code.cor-lab.org/git/rsb.git.spread-cpp', :using => :git
 
   option :universal

--- a/rsb-tools-cl.rb
+++ b/rsb-tools-cl.rb
@@ -2,13 +2,13 @@ require 'formula'
 
 class RsbToolsCl < Formula
   homepage 'https://code.cor-lab.org/projects/rsb'
-  url 'https://ci.cor-lab.org/job/rsb-tools-cl-0.13-macos/label=MAC_OS_mavericks_64bit/lastSuccessfulBuild/artifact/build/rsb', :using => :nounzip
-  sha256 '84c594ae44af97620a1d636e4f68cb13e579c9d5fcd7da9637ae024440a15f54'
-  version '0.13'
+  url 'https://ci.cor-lab.org/job/rsb-tools-cl-0.15-macos/label=MAC_OS_mavericks_64bit/lastSuccessfulBuild/artifact/build/rsb', :using => :nounzip
+  sha256 '8a7194ae578ce25d2b47ce2303fdc4cf49661fe818e70dff765ea3cc768a71b5'
+  version '0.15'
 
   def install
     bin.install 'rsb'
-    ln_s bin/'rsb', bin/'rsb0.13'
+    ln_s bin/'rsb', bin/'rsb0.15'
   end
 
   def test

--- a/rsb-tools-cpp.rb
+++ b/rsb-tools-cpp.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class RsbToolsCpp < Formula
   homepage 'https://toolkit.cit-ec.uni-bielefeld.de/components/generic/robotics-service-bus'
-  url 'https://code.cor-lab.org/git/rsb.git.tools-cpp', :using => :git, :branch => '0.13'
-  version '0.13'
+  url 'https://code.cor-lab.org/git/rsb.git.tools-cpp', :using => :git, :branch => '0.15'
+  version '0.15'
   head 'https://code.cor-lab.org/git/rsb.git.tools-cpp', :using => :git
 
   option :universal

--- a/rsb-yarp-cpp.rb
+++ b/rsb-yarp-cpp.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class RsbYarpCpp < Formula
   homepage 'https://toolkit.cit-ec.uni-bielefeld.de/components/generic/robotics-service-bus'
-  url 'https://code.cor-lab.org/git/rsb.git.yarp-cpp', :using => :git, :branch => '0.13'
-  version '0.13'
+  url 'https://code.cor-lab.org/git/rsb.git.yarp-cpp', :using => :git, :branch => '0.15'
+  version '0.15'
   head 'https://code.cor-lab.org/git/rsb.git.yarp-cpp', :using => :git
 
   option :universal

--- a/rsb.rb
+++ b/rsb.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class Rsb < Formula
   homepage 'https://toolkit.cit-ec.uni-bielefeld.de/components/generic/robotics-service-bus'
-  url 'https://code.cor-lab.org/git/rsb.git.cpp', :using => :git, :branch => '0.13'
-  version '0.13'
+  url 'https://code.cor-lab.org/git/rsb.git.cpp', :using => :git, :branch => '0.15'
+  version '0.15'
   head 'https://code.cor-lab.org/git/rsb.git.cpp', :using => :git
 
   option :universal

--- a/rsbag-tools-cl.rb
+++ b/rsbag-tools-cl.rb
@@ -2,14 +2,14 @@ require 'formula'
 
 class RsbagToolsCl < Formula
   homepage 'https://code.cor-lab.org/projects/rsbag'
-  url 'https://ci.cor-lab.org/job/rsbag-tools-cl-0.13-macos/label=MAC_OS_mavericks_64bit/lastSuccessfulBuild/artifact/build/rsbag', :using => :nounzip
-  sha256 '0a1934d053fc61e254ad73226171e7b07bb15c22e37c7b1cafb4661c608ab53c'
-  version '0.13'
+  url 'https://ci.cor-lab.org/job/rsbag-tools-cl-0.15-macos/label=MAC_OS_mavericks_64bit/lastSuccessfulBuild/artifact/build/rsbag', :using => :nounzip
+  sha256 '9e877192ae889006bc69ae5657532f314ea89756da0e71415fde92d6a4712fe2'
+  version '0.15'
   #head 'https://ci.cor-lab.org/view/rsx-trunk/job/rsbag-tools-cl-trunk-macos/label=MAC_OS_lion_64bit/lastSuccessfulBuild/artifact/build/rsbag', :using => :nounzip
 
   def install
     bin.install 'rsbag'
-    ln_s bin/'rsbag', bin/'rsbag0.13'
+    ln_s bin/'rsbag', bin/'rsbag0.15'
   end
 
   def test

--- a/rsc.rb
+++ b/rsc.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class Rsc < Formula
   homepage 'https://toolkit.cit-ec.uni-bielefeld.de/components/generic/robotics-systems-commons'
-  url 'https://code.cor-lab.org/git/rsc.git', :using => :git, :branch => '0.13'
-  version '0.13'
+  url 'https://code.cor-lab.org/git/rsc.git', :using => :git, :branch => '0.15'
+  version '0.15'
   head 'https://code.cor-lab.org/git/rsc.git', :using => :git
 
   option :universal

--- a/rst-converters.rb
+++ b/rst-converters.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class RstConverters < Formula
   homepage 'https://toolkit.cit-ec.uni-bielefeld.de/components/generic/robotics-system-types'
-  url 'https://code.cor-lab.de/git/rst.git.converters.git', :using => :git, :branch => '0.13'
-  version '0.13'
+  url 'https://code.cor-lab.de/git/rst.git.converters.git', :using => :git, :branch => '0.15'
+  version '0.15'
   head 'https://code.cor-lab.de/git/rst.git.converters.git', :using => :git
 
   option :universal

--- a/rst-proto.rb
+++ b/rst-proto.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class RstProto < Formula
   homepage 'https://toolkit.cit-ec.uni-bielefeld.de/components/generic/robotics-system-types'
-  url 'https://code.cor-lab.de/git/rst.git.proto.git', :using => :git, :branch => '0.13'
-  version '0.13'
+  url 'https://code.cor-lab.de/git/rst.git.proto.git', :using => :git, :branch => '0.15'
+  version '0.15'
   head 'https://code.cor-lab.de/git/rst.git.proto.git', :using => :git
 
   option :universal


### PR DESCRIPTION
Since 0.15 is considered the current stable version. The homebrew formulas may be updated.

I have also adapted the checksums for rsb[ag]-tools-cl/cpp.

Successful built (including dependencies):
* rsbag-tools-cl
* rsb-tools-cpp
* rsb-tools-cl
* rst-proto